### PR TITLE
Add scraper utility and DB creation action

### DIFF
--- a/app/actions/__tests__/scraper.test.ts
+++ b/app/actions/__tests__/scraper.test.ts
@@ -1,0 +1,20 @@
+import { scrapeSite } from '../scraper';
+import { extract } from '@extractus/article-extractor';
+
+jest.mock('@extractus/article-extractor');
+
+const mockedExtract = extract as jest.MockedFunction<typeof extract>;
+
+describe('scrapeSite', () => {
+  it('returns parsed article fields', async () => {
+    mockedExtract.mockResolvedValue({
+      title: 'Hello',
+      content: '<p>world</p>',
+      image: 'img.jpg',
+    } as any);
+
+    const result = await scrapeSite('https://example.com');
+    expect(result).toEqual({ title: 'Hello', content: '<p>world</p>', cover: 'img.jpg' });
+    expect(mockedExtract).toHaveBeenCalledWith('https://example.com');
+  });
+});

--- a/app/actions/createSiteFromURL.ts
+++ b/app/actions/createSiteFromURL.ts
@@ -1,32 +1,18 @@
-
-
-// app/actions/createSiteFromURL.ts
 "use server";
 
-import { z } from "zod";
-import scrapeSite from "./scraper";                   // 同ディレクトリ
-import { prisma } from "@/lib/prisma";                // ← パスは環境に合わせて調整
+import { z } from 'zod';
+import scrapeSite from './scraper';
+import { prisma } from '@/lib/prisma';
 
-/** 返却値 */
 export interface CreateSiteResult {
   projectId: string;
   pageId: string;
 }
 
-/**
- * URL を受け取り:
- *  1. scrapeSite(url) でタイトル／本文／OG画像を抽出
- *  2. prisma.project & prisma.page にレコードを登録
- *  3. 作成した ID を返す
- */
 export async function createSiteFromURL(rawUrl: string): Promise<CreateSiteResult> {
-  // ---- 1. 入力バリデーション --------------------------------------------------
   const url = z.string().url().parse(rawUrl);
-
-  // ---- 2. スクレイピング -------------------------------------------------------
   const { title, content, cover } = await scrapeSite(url);
 
-  // ---- 3. DB 登録（トランザクション）-------------------------------------------
   const result = await prisma.$transaction(async (tx) => {
     const project = await tx.project.create({
       data: { url, title, cover },
@@ -44,7 +30,6 @@ export async function createSiteFromURL(rawUrl: string): Promise<CreateSiteResul
     return { project, page };
   });
 
-  // ---- 4. 作成した ID を返却 ---------------------------------------------------
   return { projectId: result.project.id, pageId: result.page.id };
 }
 

--- a/app/actions/scraper.ts
+++ b/app/actions/scraper.ts
@@ -1,8 +1,5 @@
-// app/actions/scraper.ts
-import { extract } from "@extractus/article-extractor";
-import { z } from "zod";
+import { extract } from '@extractus/article-extractor';
 
-/** 取得結果の型 */
 export interface ScrapedArticle {
   title: string;
   content: string;
@@ -10,22 +7,15 @@ export interface ScrapedArticle {
 }
 
 /**
- * 任意 URL を受け取り、記事タイトル・本文 (HTML)・OG 画像 URL を抽出して返す
- * @param url 対象ページの URL
+ * Fetches article information from the provided URL.
  */
 export async function scrapeSite(url: string): Promise<ScrapedArticle> {
-  // ---- 入力バリデーション ----------------------------------------------------
-  z.string().url().parse(url);
-
-  // ---- 抽出 ------------------------------------------------------------------
   const article = await extract(url);
-
   return {
-    title: article?.title?.trim() ?? "Untitled",
-    content: article?.content ?? "<p>No content extracted</p>",
+    title: article?.title?.trim() ?? 'Untitled',
+    content: article?.content ?? '',
     cover: article?.image ?? null,
   };
 }
 
-// `import scrapeSite from "./scraper"` 形式でも使えるように default エクスポート
 export default scrapeSite;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "prisma generate --no-engine && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@better-fetch/fetch": "^1.1.18",
@@ -61,6 +62,9 @@
     "tailwindcss": "^4",
     "tsx": "^4.19.4",
     "tw-animate-css": "^1.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- implement `scrapeSite` for article extraction
- add Jest test for the scraper
- create `createSiteFromURL` action that saves scraped data via Prisma

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*